### PR TITLE
feat: Added post page & convs are children

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 
 import ConnectPage from './pages/ConnectPage.jsx'
 import LandingPage from './pages/LandingPage.jsx'
+import PostPage from './pages/PostPage.jsx'
 import ConversationsPage from './pages/ConversationsPage.jsx'
 import ConversationPage from './pages/ConversationPage.jsx'
 import NotFoundPage from './pages/NotFoundPage.jsx'
@@ -12,7 +13,8 @@ import './index.css'
 
 /* Ciprian 5 apr: routing system
 Use <Link to=""> instead of <a href=""> 
-TODO: If the user is not connected, redirect at "/connect" */
+TODO: If the user is not connected, redirect at "/connect" 
+TODO: Redirect the user to the most recent conv if he types manually "/conversation" (without or invalid ID) in the URL*/
 
 const router = createBrowserRouter([
   {
@@ -21,18 +23,24 @@ const router = createBrowserRouter([
     errorElement: <NotFoundPage/>
   },
   {
+    path: '/post/:postId',
+    element: <PostPage/>
+  },
+  {
     path: '/connect',
     element: <ConnectPage/>
   },
   {
     path: '/conversation',
-    element: <ConversationsPage/>
+    element: <ConversationsPage/>,
+    children: [
+      {
+        path: '/conversation/:conversationId',
+        element: <ConversationPage/>
+        /* Ciprian: This can be reverted to be a separate page if needed */
+      }
+    ]
   },
-  {
-    path: '/conversation/:conversationId',
-    element: <ConversationPage/>
-    /* This needs to be a child if all convs will be on the left and current conv on the right */
-  }
 ]);
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/src/pages/ConversationsPage.jsx
+++ b/src/pages/ConversationsPage.jsx
@@ -5,17 +5,23 @@ If the user will have all convs on the left and the current one on the right, th
 Otherwise, most likely it will be deleted
 */
 
-import { Link } from "react-router-dom";
+import { NavLink, Outlet } from "react-router-dom";
 
 function ConversationsPage() {
     const conversationsIds = [1, 2, 3, 4];
     return (
-        <div class="flex flex-col gap-2">
-            {conversationsIds.map((convId) => (
-                <Link key={convId} to={`/conversation/${convId}`}>
-                    ID conversatie: {convId}
-                </Link>
-            ))}
+        <div className="flex gap-2">
+            <div class="flex flex-col gap-2">
+                {conversationsIds.map((convId) => (
+                    // Highlight the selected conversation on the left navbar. Change the returned classes in order to do the final styling
+                    <NavLink key={convId} to={`/conversation/${convId}`} className={({isActive}) => {
+                        return isActive ? 'text-slate-500' : '';
+                    }}>
+                        ID conversatie: {convId}
+                    </NavLink>
+                ))}
+            </div>
+            <Outlet />
         </div>
     );
 }

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -13,7 +13,8 @@ function LandingPage() {
         < Post userName='Samuel Jackson' title='The title goes here' content='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut ' upVotesCount={124} commentsCount={12}/>
         <div className="flex flex-col gap-1 temporary">
             <Link to="/connect">Conectare</Link>
-            <Link to="/conversation">Conversatii</Link>
+            <Link to="/conversation">Conversatie</Link>
+            <Link to="/post/1">Postare</Link>
         </div>  
     </>);
 }

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -1,0 +1,13 @@
+import {useParams} from 'react-router-dom'
+
+function PostPage() {
+    const params = useParams();
+    console.log(params);
+    return (
+        <div className="font-bold text-4xl text-blue-700 uppercase tracking-wide">
+            Postare individuala, ID: {params.postId}
+        </div>
+    );
+}
+
+export default PostPage


### PR DESCRIPTION
1. Added in the routing system a separate page for a singular post.
2. Modified the concept of conversations, now all the convs are in the left of the current conversation. (May be easily reverted if necessary, to be discussed).