### PR TITLE
Fixes for messages

### DIFF
--- a/src/components/Messages/MessageLink.jsx
+++ b/src/components/Messages/MessageLink.jsx
@@ -12,7 +12,13 @@ const MessageLink = ({ username, id, type }) => {
     if(id == parseInt(localStorage.getItem("UserId"), 10)) {
         hashedUsername = encryptData("vocile", id);
     } else {
-        hashedUsername = encryptData(username, id);
+        // In case you click on someone's post with a new name, but you already have him in the conv by an old name
+        const storedMessages = JSON.parse(localStorage.getItem('messages')) || {};
+        if (storedMessages[id]) {
+            hashedUsername = encryptData(storedMessages[id].username, id);
+        } else { // Completely new user
+            hashedUsername = encryptData(username, id);
+        }
     }
 
     const handleClick = async (e) => {

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,15 +1,19 @@
 import io from 'socket.io-client';
 
-// const socket = io(`${import.meta.env.VITE_URL_BACKEND}`, 
-//     {
-//         rejectUnauthorized: false
-//     }
-// );
-
-const socket = io(`${import.meta.env.VITE_URL_BACKEND}`);
+const socket = io(import.meta.env.VITE_URL_SITE, {
+    path: import.meta.env.VITE_SOCKET_PATH,
+});
 
 socket.on('connect', () => {
     console.log('Connected to server, Socket ID:', socket.id);
+});
+
+socket.on('connect_error', (err) => {
+    console.error('Connection error:', err);
+});
+
+socket.on('disconnect', (reason) => {
+    console.log('Disconnected:', reason);
 });
 
 export default socket;


### PR DESCRIPTION
Two fixes:
1. If you message username x and then username y, but they are in fact the same user (name is different due to post/comment being made in a different session) - you will be redirected when clicked on the second username to the chat of the first one
TLDR: Same user, different names => same chat

2. socket initialization fix for DevOps